### PR TITLE
make mathjax support inline, and add post copyright

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -24,6 +24,8 @@
         </div>
     </section>
 
+    {{ partial "post-copyright" . }}
+
     {{ template "_internal/disqus.html" . }}
     {{ partial "share" . }}
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -10,6 +10,9 @@
 <script type="text/x-mathjax-config">
 MathJax.Hub.Config({
   tex2jax: {
+    inlineMath: [['$','$'], ['\\(','\\)']],
+    displayMath: [['$$','$$'], ['\\[','\\]']],
+    processEscapes: true,
     skipTags: ['script', 'noscript', 'style', 'textarea', 'pre']
   }
 });

--- a/layouts/partials/post-copyright.html
+++ b/layouts/partials/post-copyright.html
@@ -1,0 +1,5 @@
+<section class="post-copyright">
+    <p>{{ .Site.Params.postCopyrightStr}}</p>
+    <p><img src="{{ .Site.Params.postCopyrightImgAddr }}" alt="qr code" /></p>
+</section>
+


### PR DESCRIPTION
1. Make Mathjax support inline `$1+1$`.
2. Solve https://github.com/cosname/cosx.org/issues/7